### PR TITLE
Remove pyarrow<5 pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
   
 requirements:
   host:
@@ -28,7 +28,7 @@ requirements:
     - numpy !=1.15.0,!=1.16.0
     - pandas >=0.23.0,!=1.0.0
     - prompt-toolkit
-    - pyarrow >=0.17.1,!=1.0.0,<5
+    - pyarrow >=0.17.1,!=1.0.0
     - python >=3.6
     - pyyaml
     - simplejson


### PR DESCRIPTION
Anything speaking against removing the `pyarrow<5` pin?

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
