### PR TITLE
Convert plateau-feedstock to v1 feedstock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -57,20 +67,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,5 @@ github:
 conda_forge_output_validation: true
 conda_build:
   pkg_format: '2'
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,53 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "plateau-feedstock"
+version = "3.48.1"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/plateau-feedstock"
+authors = ["@conda-forge/plateau"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build plateau-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build plateau-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of plateau-feedstock packages built for variant linux_64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,23 +1,26 @@
-{% set name = "plateau" %}
-{% set version = "4.4.0" %}
+schema_version: 1
+
+context:
+  name: plateau
+  version: 4.4.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/plateau-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/plateau-${{ version }}.tar.gz
   sha256: 75aac62514720a68abd0cc8a5581f93b04ecaccafd5e85f099a2fe6837bcb232
 
 build:
+  number: 2
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - setuptools-scm
   run:
     - attrs
@@ -30,27 +33,30 @@ requirements:
     - pandas >=0.23.0,!=1.0.0
     - prompt-toolkit
     - pyarrow >=4
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     - pyyaml
     - simplejson
     - toolz
     - urlquote >=1.1.3
     - zstandard
 
-test:
-  imports:
-    - plateau
-  commands:
-    - pip check
-  requires:
-    - pip
-    - python {{ python_min }}
+tests:
+  - python:
+      imports:
+        - plateau
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - pip check
 
 about:
-  home: https://pypi.org/project/plateau/
   license: MIT
   license_file: LICENSE.txt
   summary: A consistent table management library in Python. Flat files, flat land.
+  homepage: https://pypi.org/project/plateau/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This PR converts plateau-feedstock to a v1 recipe and switch the conda build tool to rattler-build.
It has been automatically generated with [feedrattler v0.3.13](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [ ] Ensured the license file is being packaged.
